### PR TITLE
feat: add application layer and api

### DIFF
--- a/Indt.slnx
+++ b/Indt.slnx
@@ -4,6 +4,7 @@
   <Folder Name="/src/Contract/Adapters/" />
   <Folder Name="/src/Contract/Adapters/Driven/">
     <Project Path="src/Contract.Infra/Contract.Infra.csproj" />
+    <Project Path="src\Contract.Infra.CrossCutting.Http\Contract.Infra.CrossCutting.Http.csproj" Type="Classic C#" />
   </Folder>
   <Folder Name="/src/Contract/Adapters/Driving/">
     <Project Path="src/Contract.Api/Contract.Api.csproj" />

--- a/src/Contract.Api/Contract.Api.csproj
+++ b/src/Contract.Api/Contract.Api.csproj
@@ -22,6 +22,7 @@
     <ItemGroup>
       <ProjectReference Include="..\Contract.Application\Contract.Application.csproj" />
       <ProjectReference Include="..\Contract.Domain\Contract.Domain.csproj" />
+      <ProjectReference Include="..\Contract.Infra.CrossCutting.Http\Contract.Infra.CrossCutting.Http.csproj" />
       <ProjectReference Include="..\Contract.Infra\Contract.Infra.csproj" />
     </ItemGroup>
 

--- a/src/Contract.Api/Controllers/ContractController.cs
+++ b/src/Contract.Api/Controllers/ContractController.cs
@@ -19,14 +19,12 @@ public class ContractController(
     /// <summary>
     /// Contract a new proposal (only if its approved)
     /// </summary>
-    /// <param name="request">The game data required to create a new entry in the system.</param>
-    /// <returns>A response containing the created game, or an error message if the input is invalid.</returns>
+    /// <param name="request">The contract data required to create a new entry in the system.</param>
+    /// <returns>A response containing the created proposal, or an error message if the input is invalid.</returns>
     [HttpPost]
     [SwaggerOperation(
         Summary = "Contract a new proposal",
-        Description = "Contract a new proposal (only if its approved)",
-        OperationId = "Contract.Create",
-        Tags = new[] { "Contract" }
+        Description = "Contract a new proposal (only if its approved)"
     )]
     [ProducesResponseType(typeof(BaseResponse<ContractResponse>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(BaseResponse<object>), StatusCodes.Status400BadRequest)]
@@ -38,6 +36,28 @@ public class ContractController(
     public async Task<IActionResult> Create([FromBody] ContractRequest request)
     {
         var result = await contractService.ContractProposalAsync(request);
+        return Response(BaseResponse<ContractResponse>.Ok(result));
+    }
+    
+    /// <summary>
+    /// Get contract by id
+    /// </summary>
+    /// <returns>A response containing the contract.</returns>
+    [HttpGet("{id:int:min(1)}")]
+    [SwaggerOperation(
+        Summary = "Get Contract by id",
+        Description = "Get Contract by id available in the system."
+    )]
+    [ProducesResponseType(typeof(BaseResponse<ContractResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(BaseResponse<object>), StatusCodes.Status400BadRequest)]
+    [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(GenericErrorBadRequestExample))]
+    [ProducesResponseType(typeof(BaseResponse<object>), StatusCodes.Status409Conflict)]
+    [SwaggerResponseExample(StatusCodes.Status409Conflict, typeof(GenericErrorConflictExample))]
+    [ProducesResponseType(typeof(BaseResponse<object>), StatusCodes.Status500InternalServerError)]
+    [SwaggerResponseExample(StatusCodes.Status500InternalServerError, typeof(GenericErrorInternalServerExample))]
+    public async Task<IActionResult> GetAsync(int id)
+    {
+        var result = await contractService.GetContractByIdAsync(id);
         return Response(BaseResponse<ContractResponse>.Ok(result));
     }
 }

--- a/src/Contract.Api/Program.cs
+++ b/src/Contract.Api/Program.cs
@@ -1,7 +1,9 @@
 using System.Diagnostics.CodeAnalysis;
 using Contract.Api.Extensions;
 using Contract.Api.Middlewares;
+using Contract.Application;
 using Contract.Infra;
+using Contract.Infra.Http;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -15,6 +17,10 @@ builder.Services.AddDbContext<Context>(options =>
     options.UseNpgsql(connectionString));
 
 builder.Services.AddCustomMvc();
+
+builder.Services.AddInfraModuleDependency();
+builder.Services.AddApplicationModule();
+builder.Services.AddInfraHttp(builder.Configuration);
 
 builder.Services.AddGlobalCorsPolicy();
 

--- a/src/Contract.Api/appsettings.Development.json
+++ b/src/Contract.Api/appsettings.Development.json
@@ -7,5 +7,10 @@
   },
   "ConnectionStrings": {
     "DefaultConnection": "Server=localhost;Database=Contract;Username=postgres;Password=admin"
+  },
+  "App": {
+    "Settings": {
+      "ProposalUrl": "https://localhost:5001/api/v1/proposals"
+    }
   }
 }

--- a/src/Contract.Api/appsettings.json
+++ b/src/Contract.Api/appsettings.json
@@ -5,5 +5,12 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost;Database=Contract;Username=postgres;Password=admin"
+  },
+  "App": {
+    "Settings": {
+      "ProposalUrl": "https://localhost:5001/api/v1/proposals"
+    }
+  }
 }

--- a/src/Contract.Application/ApplicationModuleDependency.cs
+++ b/src/Contract.Application/ApplicationModuleDependency.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Contract.Application.Contract.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Contract.Application;
 

--- a/src/Contract.Application/Contract.Application.csproj
+++ b/src/Contract.Application/Contract.Application.csproj
@@ -8,10 +8,12 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Contract.Domain\Contract.Domain.csproj" />
+      <ProjectReference Include="..\Contract.Infra.CrossCutting.Http\Contract.Infra.CrossCutting.Http.csproj" />
     </ItemGroup>
 
     <ItemGroup>
       <PackageReference Include="FluentValidation" Version="12.0.0" />
+      <PackageReference Include="Mapster" Version="7.4.2-pre02" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
     </ItemGroup>

--- a/src/Contract.Application/Contract/Models/Request/ContractRequest.cs
+++ b/src/Contract.Application/Contract/Models/Request/ContractRequest.cs
@@ -1,6 +1,9 @@
 ﻿namespace Contract.Application.Contract.Models.Request;
 
-public class ContractRequest
+public record ContractRequest
 {
-    
+    public int Id { get; set; }
+    public string InsuranceNameHolder { get; set; }
+    public string CPF { get; set; }
+    public decimal Money { get; set; }
 }

--- a/src/Contract.Application/Contract/Models/Response/ContractResponse.cs
+++ b/src/Contract.Application/Contract/Models/Response/ContractResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace Contract.Application.Contract.Models.Response;
 
-public class ContractResponse
+public record ContractResponse
 {
     
 }

--- a/src/Contract.Application/Contract/Services/ContractService.cs
+++ b/src/Contract.Application/Contract/Services/ContractService.cs
@@ -2,7 +2,10 @@
 using Contract.Application.Contract.Models.Request;
 using Contract.Application.Contract.Models.Response;
 using Contract.Domain.Contract;
+using Contract.Domain.Contract.ValueObjects;
 using Contract.Domain.SeedWork;
+using Contract.Infra.Http.Proposal;
+using Mapster;
 using Microsoft.Extensions.Logging;
 
 namespace Contract.Application.Contract.Services;
@@ -10,11 +13,44 @@ namespace Contract.Application.Contract.Services;
 public class ContractService(
     INotification notification,
     IContractRepository repository,
-    ILogger<ContractService> logger
+    ILogger<ContractService> logger,
+    IProposalService proposalService
     ) : BaseService(notification), IContractService
 {
-    public Task<ContractResponse> ContractProposalAsync(ContractRequest request)
+    public async Task<ContractResponse> ContractProposalAsync(ContractRequest request)
     {
-        throw new NotImplementedException();
+        var proposal = await proposalService.GetProposalAsync(request.Id);
+        if (proposal == null)
+        {
+            notification.AddNotification("Proposal", "Proposal not found", NotificationModel.ENotificationType.NotFound);
+            return null!;
+        }
+
+        Domain.Contract.Contract contract;
+
+        contract = Domain.Contract.Contract.Create(
+            proposalId: request.Id,
+            proposalStatus: proposal.ProposalStatus,
+            insuranceNameHolder: request.InsuranceNameHolder,
+            cpf: new CPF(request.CPF),
+            monthlyBill: new Money(request.Money)
+        );
+
+        await repository.InsertOrUpdateAsync(contract);
+        await repository.SaveChangesAsync();
+
+        return contract.Adapt<ContractResponse>();
+    }
+    
+    public async Task<ContractResponse> GetContractByIdAsync(int contractId)
+    {
+        var contract = await repository.GetByIdAsync(contractId, noTracking: true);
+        if (contract == null)
+        {
+            notification.AddNotification("Contract", "Contract not found", NotificationModel.ENotificationType.NotFound);
+            return null!;
+        }
+        
+        return contract.Adapt<ContractResponse>();
     }
 }

--- a/src/Contract.Application/Contract/Services/IContractService.cs
+++ b/src/Contract.Application/Contract/Services/IContractService.cs
@@ -6,4 +6,5 @@ namespace Contract.Application.Contract.Services;
 public interface IContractService
 {
     Task<ContractResponse> ContractProposalAsync(ContractRequest request);
+    Task<ContractResponse> GetContractByIdAsync(int contractId);
 }

--- a/src/Contract.Domain/ContractAggregate/Contract.cs
+++ b/src/Contract.Domain/ContractAggregate/Contract.cs
@@ -11,7 +11,7 @@ public class Contract : Entity, IAggregateRoot
     public DateTime ContractDate { get; set; }
     public int ProposalId { get; set; }
     public string InsuranceNameHolder { get; set; }
-    public ProposalStatusEnum ProposalStatus { get; set; }
+    public string ProposalStatus { get; set; }
     public CPF CPF { get; set; }
     public Money MonthlyBill { get; set; }
     
@@ -37,13 +37,13 @@ public class Contract : Entity, IAggregateRoot
     
     public static Contract Create(
         int proposalId,
-        ProposalStatusEnum proposalStatus,
+        string proposalStatus,
         string insuranceNameHolder,
         CPF cpf,
         Money monthlyBill,
         DateTime? contractDate = null)
     {
-        if (proposalStatus != ProposalStatusEnum.Approved)
+        if (proposalStatus != ProposalStatusEnum.Approved.ToString())
             throw new BusinessRulesException("Proposal not approved to proceed");
 
         if (string.IsNullOrWhiteSpace(insuranceNameHolder))

--- a/src/Contract.Infra.CrossCutting.Http/AddInfraHttpModule.cs
+++ b/src/Contract.Infra.CrossCutting.Http/AddInfraHttpModule.cs
@@ -1,0 +1,21 @@
+﻿using Contract.Infra.Http.Proposal;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Contract.Infra.Http;
+
+public static class AddInfraHttpModule
+{
+    public static IServiceCollection AddInfraHttp(this IServiceCollection services, IConfiguration configuration)
+    {
+        var urlProposal = configuration["App:Settings:ProposalUrl"];
+        
+        services.AddHttpClient<IProposalService, ProposalService>(c =>
+        {
+            c.BaseAddress = new Uri(urlProposal);
+            c.Timeout = TimeSpan.FromSeconds(10);
+        });
+
+        return services;
+    }
+}

--- a/src/Contract.Infra.CrossCutting.Http/BaseHttpService.cs
+++ b/src/Contract.Infra.CrossCutting.Http/BaseHttpService.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Contract.Infra.Http;
+
+[ExcludeFromCodeCoverage]
+public abstract class BaseHttpService(HttpClient httpClient)
+{
+    protected async Task<T> GetAsync<T>(string url, NameValueCollection? queryParams) where T : new()
+    {
+        if (queryParams is not null)
+        {
+            url = $"{url}?{queryParams}";
+        }
+
+        var response = await httpClient.GetAsync(url);
+
+        response.EnsureSuccessStatusCode();
+
+        return await DeserializeResponse<T>(response);
+    }
+
+    protected async Task<T> GetAsync<T>(string url) where T : new()
+    {
+        return await GetAsync<T>(url, null);
+    }
+
+    protected async Task<T> PostAsync<T>(string url, object request) where T : new()
+    {
+        var json = JsonConvert.SerializeObject(request);
+        var body = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await httpClient.PostAsync(url, body);
+
+        response.EnsureSuccessStatusCode();
+
+        return await DeserializeResponse<T>(response);
+    }
+
+    private static async Task<T> DeserializeResponse<T>(HttpResponseMessage response)
+    {
+        var responseMessage = await response.Content.ReadAsStringAsync();
+        return JsonConvert.DeserializeObject<T>(responseMessage)!;
+    }
+}

--- a/src/Contract.Infra.CrossCutting.Http/Contract.Infra.CrossCutting.Http.csproj
+++ b/src/Contract.Infra.CrossCutting.Http/Contract.Infra.CrossCutting.Http.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <RootNamespace>Contract.Infra.Http</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    </ItemGroup>
+
+</Project>

--- a/src/Contract.Infra.CrossCutting.Http/Proposal/Dtos/ProposalResponse.cs
+++ b/src/Contract.Infra.CrossCutting.Http/Proposal/Dtos/ProposalResponse.cs
@@ -1,0 +1,9 @@
+﻿namespace Contract.Infra.Http.Proposal.Dtos;
+
+public class ProposalResponse
+{
+    public int Id { get; set; }
+    public DateTime CreationDate { get; set; }
+    public string ProposalStatus { get; set; }
+    public string InsuranceType { get; set; }
+}

--- a/src/Contract.Infra.CrossCutting.Http/Proposal/IProposalService.cs
+++ b/src/Contract.Infra.CrossCutting.Http/Proposal/IProposalService.cs
@@ -1,0 +1,8 @@
+﻿using Contract.Infra.Http.Proposal.Dtos;
+
+namespace Contract.Infra.Http.Proposal;
+
+public interface IProposalService
+{
+    Task<ProposalResponse> GetProposalAsync(int proposalId);
+}

--- a/src/Contract.Infra.CrossCutting.Http/Proposal/ProposalService.cs
+++ b/src/Contract.Infra.CrossCutting.Http/Proposal/ProposalService.cs
@@ -1,0 +1,12 @@
+﻿using Contract.Infra.Http.Proposal.Dtos;
+using Microsoft.Extensions.Logging;
+
+namespace Contract.Infra.Http.Proposal;
+
+public class ProposalService(HttpClient client, ILogger<ProposalService> logger) : BaseHttpService(client), IProposalService
+{
+    public Task<ProposalResponse> GetProposalAsync(int proposalId)
+    {
+        return GetAsync<ProposalResponse>($"api/v1/proposal/{proposalId}");
+    }
+}

--- a/src/Contract.Infra/InfraModuleDependency.cs
+++ b/src/Contract.Infra/InfraModuleDependency.cs
@@ -8,7 +8,7 @@ namespace Contract.Infra;
 
 public static class InfraModuleDependency
 {
-    public static void AddInfraModuleDependency(this IServiceCollection services, IConfiguration configuration)
+    public static void AddInfraModuleDependency(this IServiceCollection services)
     {
         services.AddScoped<INotification, Notification>();
         services.AddScoped<IUnitOfWork, UnitOfWork>();

--- a/src/Proposal.Api/Controllers/ProposalController.cs
+++ b/src/Proposal.Api/Controllers/ProposalController.cs
@@ -1,6 +1,111 @@
-﻿namespace Proposal.Api.Controllers;
+﻿using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using Proposal.Api.SwaggerExamples.Commons;
+using Proposal.Application.Common;
+using Proposal.Application.Proposal.Models.Request;
+using Proposal.Application.Proposal.Models.Response;
+using Proposal.Application.Proposal.Services;
+using Proposal.Domain.Enums;
+using Proposal.Domain.SeedWork;
+using Swashbuckle.AspNetCore.Annotations;
+using Swashbuckle.AspNetCore.Filters;
 
-public class ProposalController
+namespace Proposal.Api.Controllers;
+
+public class ProposalController(
+    IProposalService proposalService,
+    INotification notification
+) 
+    : BaseController(notification)
 {
+    /// <summary>
+    /// Create a new proposal in the system.
+    /// </summary>
+    /// <param name="request">The insurance type required to create a new entry in the system.</param>
+    /// <returns>A response containing the created proposal, or an error message if the input is invalid.</returns>
+    [HttpPost]
+    [SwaggerOperation(
+        Summary = "Create a new proposal in the system.",
+        Description = "Create a new proposal in the system."
+    )]
+    [ProducesResponseType(typeof(BaseResponse<ProposalResponse>), (int)HttpStatusCode.Created)]
+    [ProducesResponseType(typeof(BaseResponse<object>), StatusCodes.Status400BadRequest)]
+    [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(GenericErrorBadRequestExample))]
+    [ProducesResponseType(typeof(BaseResponse<object>), StatusCodes.Status409Conflict)]
+    [SwaggerResponseExample(StatusCodes.Status409Conflict, typeof(GenericErrorConflictExample))]
+    [ProducesResponseType(typeof(BaseResponse<object>), StatusCodes.Status500InternalServerError)]
+    [SwaggerResponseExample(StatusCodes.Status500InternalServerError, typeof(GenericErrorInternalServerExample))]
+    public async Task<IActionResult> CreateAsync([FromBody] ProposalRequest request)
+    {
+        var result = await proposalService.CreateProposalAsync(request);
+        return Response(BaseResponse<ProposalResponse>.Ok(result));
+    }
     
+    /// <summary>
+    /// Update proposal status in the system.
+    /// </summary>
+    /// <param name="id">The ID of the proposal to be updated (must be greater than 0).</param>
+    /// <param name="request">The status required to update a proposal in the system.</param>
+    /// <returns>A response containing the proposal, or an error message if the input is invalid.</returns>
+    [HttpPatch("{id:int:min(1)}")]
+    [SwaggerOperation(
+        Summary = "Update proposal status in the system.",
+        Description = "Update a status from a proposal in the system."
+    )]
+    [ProducesResponseType((int)HttpStatusCode.NoContent)]
+    [ProducesResponseType(typeof(BaseResponse<object>), StatusCodes.Status400BadRequest)]
+    [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(GenericErrorBadRequestExample))]
+    [ProducesResponseType(typeof(BaseResponse<object>), StatusCodes.Status409Conflict)]
+    [SwaggerResponseExample(StatusCodes.Status409Conflict, typeof(GenericErrorConflictExample))]
+    [ProducesResponseType(typeof(BaseResponse<object>), StatusCodes.Status500InternalServerError)]
+    [SwaggerResponseExample(StatusCodes.Status500InternalServerError, typeof(GenericErrorInternalServerExample))]
+    public async Task<IActionResult> UpdateAsync(int id, [FromBody] EProposalStatus request)
+    {
+        await proposalService.UpdateProposalAsync(id, request);
+        return Response(BaseResponse<ProposalResponse>.Ok(null));
+    }
+    
+    /// <summary>
+    /// Get all proposals
+    /// </summary>
+    /// <returns>A response containing the proposals.</returns>
+    [HttpGet]
+    [SwaggerOperation(
+        Summary = "Get All Proposals",
+        Description = "Get all proposals availables in the system."
+    )]
+    [ProducesResponseType(typeof(BaseResponse<List<ProposalResponse>>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(BaseResponse<object>), StatusCodes.Status400BadRequest)]
+    [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(GenericErrorBadRequestExample))]
+    [ProducesResponseType(typeof(BaseResponse<object>), StatusCodes.Status409Conflict)]
+    [SwaggerResponseExample(StatusCodes.Status409Conflict, typeof(GenericErrorConflictExample))]
+    [ProducesResponseType(typeof(BaseResponse<object>), StatusCodes.Status500InternalServerError)]
+    [SwaggerResponseExample(StatusCodes.Status500InternalServerError, typeof(GenericErrorInternalServerExample))]
+    public async Task<IActionResult> GetAllAsync()
+    {
+        var result = await proposalService.GetProposalsAsync();
+        return Response(BaseResponse<List<ProposalResponse>>.Ok(result));
+    }
+    
+    /// <summary>
+    /// Get proposal by id
+    /// </summary>
+    /// <returns>A response containing the proposal.</returns>
+    [HttpGet("{id:int:min(1)}")]
+    [SwaggerOperation(
+        Summary = "Get Proposal",
+        Description = "Get proposal by id available in the system."
+    )]
+    [ProducesResponseType(typeof(BaseResponse<ProposalResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(BaseResponse<object>), StatusCodes.Status400BadRequest)]
+    [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(GenericErrorBadRequestExample))]
+    [ProducesResponseType(typeof(BaseResponse<object>), StatusCodes.Status409Conflict)]
+    [SwaggerResponseExample(StatusCodes.Status409Conflict, typeof(GenericErrorConflictExample))]
+    [ProducesResponseType(typeof(BaseResponse<object>), StatusCodes.Status500InternalServerError)]
+    [SwaggerResponseExample(StatusCodes.Status500InternalServerError, typeof(GenericErrorInternalServerExample))]
+    public async Task<IActionResult> GetAsync(int id)
+    {
+        var result = await proposalService.GetProposalAsync(id);
+        return Response(BaseResponse<ProposalResponse>.Ok(result));
+    }
 }

--- a/src/Proposal.Api/Proposal.Api.csproj
+++ b/src/Proposal.Api/Proposal.Api.csproj
@@ -21,6 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\Contract.Api\Contract.Api.csproj" />
       <ProjectReference Include="..\Proposal.Application\Proposal.Application.csproj" />
       <ProjectReference Include="..\Proposal.Domain\Proposal.Domain.csproj" />
       <ProjectReference Include="..\Proposal.Infra\Proposal.Infra.csproj" />

--- a/src/Proposal.Api/SwaggerExamples/Common/GenericErrorBadRequestExample.cs
+++ b/src/Proposal.Api/SwaggerExamples/Common/GenericErrorBadRequestExample.cs
@@ -1,0 +1,24 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Contract.Application.Common;
+using Contract.Domain.SeedWork;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Proposal.Api.SwaggerExamples.Commons;
+
+[ExcludeFromCodeCoverage]
+public class GenericErrorBadRequestExample : IExamplesProvider<BaseResponse<object>>
+{
+    public BaseResponse<object> GetExamples()
+    {
+        var notification = new NotificationModel
+        {
+            NotificationType = NotificationModel.ENotificationType.BadRequestError
+        };
+
+        notification.AddMessage("Field", "Field Required");
+
+        notification.AddMessage("Error", "Generic validation error");
+
+        return BaseResponse<object>.Fail(notification);
+    }
+}

--- a/src/Proposal.Api/SwaggerExamples/Common/GenericErrorConflictExample.cs
+++ b/src/Proposal.Api/SwaggerExamples/Common/GenericErrorConflictExample.cs
@@ -1,0 +1,23 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Contract.Application.Common;
+using Contract.Domain.SeedWork;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Proposal.Api.SwaggerExamples.Commons;
+
+[ExcludeFromCodeCoverage]
+public class GenericErrorConflictExample : IExamplesProvider<BaseResponse<object>>
+{
+    public BaseResponse<object> GetExamples()
+    {
+        var notification = new NotificationModel
+        {
+            NotificationType = NotificationModel.ENotificationType.BusinessRules
+        };
+
+        notification.AddMessage("Field", "Field already in use");
+        notification.AddMessage("Conflict", "This resource already exists and cannot be duplicated");
+
+        return BaseResponse<object>.Fail(notification);
+    }
+}

--- a/src/Proposal.Api/SwaggerExamples/Common/GenericErrorInternalServerExample.cs
+++ b/src/Proposal.Api/SwaggerExamples/Common/GenericErrorInternalServerExample.cs
@@ -1,0 +1,23 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Contract.Application.Common;
+using Contract.Domain.SeedWork;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Proposal.Api.SwaggerExamples.Commons;
+
+[ExcludeFromCodeCoverage]
+public class GenericErrorInternalServerExample : IExamplesProvider<BaseResponse<object>>
+{
+    public BaseResponse<object> GetExamples()
+    {
+        var notification = new NotificationModel
+        {
+            NotificationType = NotificationModel.ENotificationType.InternalServerError
+        };
+
+        notification.AddMessage("Server", "An unexpected error occurred while processing your request.");
+        notification.AddMessage("Internal", "Please contact support if the problem persists.");
+
+        return BaseResponse<object>.Fail(notification);
+    }
+}

--- a/src/Proposal.Api/SwaggerExamples/Common/GenericErrorNotFoundExample.cs
+++ b/src/Proposal.Api/SwaggerExamples/Common/GenericErrorNotFoundExample.cs
@@ -1,0 +1,23 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Contract.Application.Common;
+using Contract.Domain.SeedWork;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Proposal.Api.SwaggerExamples.Commons;
+
+[ExcludeFromCodeCoverage]
+public class GenericErrorNotFoundExample : IExamplesProvider<BaseResponse<object>>
+{
+    public BaseResponse<object> GetExamples()
+    {
+        var notification = new NotificationModel
+        {
+            NotificationType = NotificationModel.ENotificationType.NotFound
+        };
+
+        notification.AddMessage("Field", "Resource not found");
+        notification.AddMessage("NotFound", "The requested resource does not exist");
+
+        return BaseResponse<object>.Fail(notification);
+    }
+}

--- a/src/Proposal.Api/SwaggerExamples/Proposals/CreateProposalExample.cs
+++ b/src/Proposal.Api/SwaggerExamples/Proposals/CreateProposalExample.cs
@@ -1,0 +1,16 @@
+﻿using Proposal.Application.Proposal.Models.Request;
+using Proposal.Domain.Enums;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Proposal.Api.SwaggerExamples.Proposals;
+
+public class CreateProposalExample : IExamplesProvider<ProposalRequest>
+{
+    public ProposalRequest GetExamples()
+    {
+        return new ProposalRequest
+        {
+            InsuranceType = EInsuranceType.Car
+        };
+    }
+}

--- a/src/Proposal.Api/appsettings.json
+++ b/src/Proposal.Api/appsettings.json
@@ -5,5 +5,7 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost;Database=Proposal;Uid=root;Pwd=admin;Port=3306;"
+  }
 }

--- a/src/Proposal.Application/Proposal.Application.csproj
+++ b/src/Proposal.Application/Proposal.Application.csproj
@@ -7,15 +7,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <Folder Include="Validators\ProposalValidators\" />
-    </ItemGroup>
-
-    <ItemGroup>
       <ProjectReference Include="..\Proposal.Domain\Proposal.Domain.csproj" />
     </ItemGroup>
 
     <ItemGroup>
       <PackageReference Include="FluentValidation" Version="12.0.0" />
+      <PackageReference Include="Mapster" Version="7.4.2-pre02" />
     </ItemGroup>
 
 </Project>

--- a/src/Proposal.Application/Proposal/Models/Request/ProposalRequest.cs
+++ b/src/Proposal.Application/Proposal/Models/Request/ProposalRequest.cs
@@ -1,6 +1,8 @@
-﻿namespace Proposal.Application.Proposal.Models.Request;
+﻿using Proposal.Domain.Enums;
 
-public class ProposalRequest
+namespace Proposal.Application.Proposal.Models.Request;
+
+public record ProposalRequest
 {
-    
+    public EInsuranceType InsuranceType { get; set; }
 }

--- a/src/Proposal.Application/Proposal/Models/Response/ProposalResponse.cs
+++ b/src/Proposal.Application/Proposal/Models/Response/ProposalResponse.cs
@@ -1,6 +1,11 @@
-﻿namespace Proposal.Application.Proposal.Models.Response;
+﻿using Proposal.Domain.Enums;
 
-public class ProposalResponse
+namespace Proposal.Application.Proposal.Models.Response;
+
+public record ProposalResponse
 {
-    
+    public int Id { get; set; }
+    public DateTime CreationDate { get; set; }
+    public EProposalStatus ProposalStatus { get; set; }
+    public EInsuranceType InsuranceType { get; set; }
 }

--- a/src/Proposal.Application/Proposal/Services/IProposalService.cs
+++ b/src/Proposal.Application/Proposal/Services/IProposalService.cs
@@ -1,6 +1,15 @@
-﻿namespace Proposal.Application.Proposal.Services;
+﻿using Proposal.Application.Common;
+using Proposal.Application.Proposal.Models.Request;
+using Proposal.Application.Proposal.Models.Response;
+using Proposal.Domain.Enums;
+
+namespace Proposal.Application.Proposal.Services;
 
 public interface IProposalService
 {
-    
+    Task<ProposalResponse> CreateProposalAsync(ProposalRequest request);
+    Task<BaseResponse<object>> UpdateProposalAsync(int proposalId, EProposalStatus request);
+    Task<List<ProposalResponse>> GetProposalsAsync();
+    Task<ProposalResponse> GetProposalAsync(int id);
+
 }

--- a/src/Proposal.Application/Proposal/Services/ProposalService.cs
+++ b/src/Proposal.Application/Proposal/Services/ProposalService.cs
@@ -1,8 +1,12 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using Mapster;
+using Microsoft.Extensions.Logging;
 using Proposal.Application.Common;
 using Proposal.Application.Proposal.Models.Request;
 using Proposal.Application.Proposal.Models.Response;
+using Proposal.Application.Validators;
+using Proposal.Application.Validators.ProposalValidators;
 using Proposal.Domain;
+using Proposal.Domain.Enums;
 using Proposal.Domain.SeedWork;
 
 namespace Proposal.Application.Proposal.Services;
@@ -13,8 +17,53 @@ public class ProposalService(
     ILogger<ProposalService> logger
 ) : BaseService(notification), IProposalService
 {
-    public Task<ProposalResponse> CreateProposalAsync(ProposalRequest request)
+    public async Task<ProposalResponse> CreateProposalAsync(ProposalRequest request)
     {
-        throw new NotImplementedException();
+        Validate(request, new CreateProposalRequestValidator());
+
+        var proposal = Domain.Proposal.Create(request.InsuranceType);
+        
+        await repository.InsertOrUpdateAsync(proposal);
+        await repository.SaveChangesAsync();
+
+        return proposal.Adapt<ProposalResponse>();
+    }
+
+    public async Task<BaseResponse<object>> UpdateProposalAsync(int proposalId, EProposalStatus request)
+    {
+        var proposal = await repository.GetByIdAsync(proposalId, noTracking: false);
+        
+        if (proposal is null)
+        {
+            notification.AddNotification("Proposal", "Proposal not found", NotificationModel.ENotificationType.NotFound);
+            return null!;
+        }
+        
+        proposal.SetStatus(request);
+        
+        await repository.UpdateAsync(proposal);
+        await repository.SaveChangesAsync();
+        
+        return BaseResponse<object>.Ok(null);
+    }
+
+    public async Task<List<ProposalResponse>> GetProposalsAsync()
+    {
+        var proposals = await repository.GetAllAsync();
+
+        return proposals.Adapt<List<ProposalResponse>>();
+    }
+
+    public async Task<ProposalResponse> GetProposalAsync(int id)
+    {
+        var proposal = await repository.GetByIdAsync(id, noTracking: true);
+        
+        if (proposal is null)
+        {
+            notification.AddNotification("Proposal", "Proposal not found", NotificationModel.ENotificationType.NotFound);
+            return null!;
+        }
+
+        return proposal.Adapt<ProposalResponse>();
     }
 }

--- a/src/Proposal.Application/Validators/ProposalValidators/CreateProposalRequestValidator.cs
+++ b/src/Proposal.Application/Validators/ProposalValidators/CreateProposalRequestValidator.cs
@@ -1,0 +1,15 @@
+﻿using FluentValidation;
+using Proposal.Application.Proposal.Models.Request;
+
+namespace Proposal.Application.Validators.ProposalValidators;
+
+public class CreateProposalRequestValidator : AbstractValidator<ProposalRequest>
+{
+    public CreateProposalRequestValidator()
+    {
+        RuleFor(x => x.InsuranceType)
+            .IsInEnum()
+            .WithMessage("Tipo de seguro inválido.");
+    }
+    
+}

--- a/src/Proposal.Domain/Proposal/Proposal.cs
+++ b/src/Proposal.Domain/Proposal/Proposal.cs
@@ -22,18 +22,12 @@ public class Proposal : Entity, IAggregateRoot
         InsuranceType = insuranceType;
     }
     
-    public static Proposal Create(EInsuranceType insuranceType, EProposalStatus? initialStatus = null)
+    public static Proposal Create(EInsuranceType insuranceType)
     {
-        var status = initialStatus ?? EProposalStatus.InAnalysis;
-        var creationDate = DateTime.Now;
-
         if (!Enum.IsDefined(typeof(EInsuranceType), insuranceType))
-            throw new ArgumentException("Invalid Insurance type", nameof(insuranceType));
+            throw new ArgumentException("Invalid insurance", nameof(insuranceType));
 
-        if (!Enum.IsDefined(typeof(EProposalStatus), status))
-            throw new ArgumentException("Invlaid Initial Status", nameof(initialStatus));
-
-        return new Proposal(insuranceType, status, creationDate);
+        return new Proposal(insuranceType, EProposalStatus.InAnalysis, DateTime.UtcNow);
     }
 
     public void SetStatus(EProposalStatus newStatus)


### PR DESCRIPTION
Added Contract.Infra.CrossCutting.Http project for HTTP communication between Contract and Proposal modules. Updated Contract and Proposal APIs to support new endpoints and response models. Introduced service interfaces, DTOs, and validators for proposal creation and retrieval. Refactored dependency injection, configuration, and controller logic to enable cross-module operations and improved API documentation with Swagger examples.